### PR TITLE
Fix: Don't remove CalendarProvider from AOSP as syncing will fail otherwise.

### DIFF
--- a/templates/build_script.go
+++ b/templates/build_script.go
@@ -333,7 +333,7 @@ fetch_aosp_source() {
   sed -i '/Browser2/d' build/make/target/product/core.mk
 
   # remove Calendar
-  sed -i '/Calendar/d' build/make/target/product/core.mk
+  sed -i '/Calendar \\/d' build/make/target/product/core.mk
 
   # remove QuickSearchBox
   sed -i '/QuickSearchBox/d' build/make/target/product/core.mk


### PR DESCRIPTION
Not only was Calendar removed during the build, but also CalendarProvider. This causes failures trying to sync calenders e.g. via DAVdroid:

The settings are showig `Sync is currently experiencing problems. It will be back shortly.` and the logs contain `Error : Failed to find provider info for com.android.calendar`.