### PR TITLE
Fix crash in `build list` on missing IAM profiles

### DIFF
--- a/cli/build.go
+++ b/cli/build.go
@@ -178,6 +178,10 @@ var buildListCmd = &cobra.Command{
 
 			for _, reservation := range resp.Reservations {
 				for _, instance := range reservation.Instances {
+					if instance.IamInstanceProfile == nil || instance.IamInstanceProfile.Arn == nil {
+						continue
+					}
+
 					instanceIamProfileName := strings.Split(*instance.IamInstanceProfile.Arn, "/")[1]
 					if instanceIamProfileName == name+"-ec2" {
 						log.Printf("Instance '%v': ip='%v' region='%v' launched='%v'", *instance.InstanceId, *instance.PublicIpAddress, region, *instance.LaunchTime)


### PR DESCRIPTION
When running `rattlesnakeos-stack build list`, if any of the EC2 instances returned by `DescribeInstances` have no associated `IamInstanceProfile`, the application will crash from a nil dereference.  This change adds a check for that (as well as a nil `Arn`), and skips the instance if either is missing.