### PR TITLE
Not all packages were set to be installed non interactively

### DIFF
--- a/templates/build_template.go
+++ b/templates/build_template.go
@@ -3,6 +3,8 @@ package templates
 const BuildTemplate = `
 #!/bin/bash
 
+export DEBIAN_FRONTEND=noninteractive
+
 if [ $# -lt 1 ]; then
   echo "Need to specify device name as argument"
   exit 1

--- a/templates/build_template.go
+++ b/templates/build_template.go
@@ -3,8 +3,6 @@ package templates
 const BuildTemplate = `
 #!/bin/bash
 
-export DEBIAN_FRONTEND=noninteractive
-
 if [ $# -lt 1 ]; then
   echo "Need to specify device name as argument"
   exit 1
@@ -136,7 +134,7 @@ FDROID_PRIV_EXT_VERSION=
 get_latest_versions() {
   log_header ${FUNCNAME}
 
-  sudo apt-get -y install jq
+  sudo DEBIAN_FRONTEND=noninteractive apt-get -y install jq
 
   # check if running latest stack
   LATEST_STACK_VERSION=$(curl --fail -s "$STACK_URL_LATEST" | jq -r '.name')
@@ -297,7 +295,7 @@ full_run() {
 }
 
 attestation_setup() {
-  sudo apt-get -y install libffi-dev
+  sudo DEBIAN_FRONTEND=noninteractive apt-get -y install libffi-dev
 
   cd $HOME
   echo "cloning beanstalk cli"
@@ -482,7 +480,7 @@ initial_key_setup() {
       fi
     fi
 
-    sudo apt-get -y install gpg
+    sudo DEBIAN_FRONTEND=noninteractive apt-get -y install gpg
     if [ ! -e "$ENCRYPTION_PIPE" ]; then
       mkfifo $ENCRYPTION_PIPE
     fi
@@ -499,7 +497,7 @@ setup_env() {
 
   # install required packages
   sudo apt-get update
-  sudo apt-get -y install repo gperf jq openjdk-8-jdk git-core gnupg flex bison build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386 lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev libxml2-utils xsltproc unzip python-networkx liblz4-tool pxz
+  sudo DEBIAN_FRONTEND=noninteractive apt-get -y install repo gperf jq openjdk-8-jdk git-core gnupg flex bison build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386 lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev libxml2-utils xsltproc unzip python-networkx liblz4-tool pxz
   sudo DEBIAN_FRONTEND=noninteractive apt-get -y build-dep "linux-image-$(uname --kernel-release)"
 
   # setup android sdk (required for fdroid build)


### PR DESCRIPTION
My most recent build hung. After investigating it turned out that the build was sitting waiting at a package prompt for user input, as a result of an apt-get install command requiring user interaction.

These changes make all apt-get install commands non-interactive, as you would expect for a non-interactive build service.