### PR TITLE
fixed keygen script to reflect changes in aws-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Rather than providing random binaries of RattlesnakeOS to install on your phone,
 ```
 keypair_name="rattlesnakeos"
 ssh-keygen -t rsa -b 4096 -f ${keypair_name}
-for region in $(aws ec2 describe-regions --output text | awk '{print $3}'); do
+for region in $(aws ec2 describe-regions --output text | awk '{print $4}'); do
   echo "Importing keypair ${keypair_name} to region ${region}..."
   aws ec2 import-key-pair --key-name "${keypair_name}" --public-key-material "file://${keypair_name}.pub" --region $region;
 done


### PR DESCRIPTION
the current aws-cli version (installed from latest pip3 repository) outputs regions like this:
`haojixu@haojis-MacBook-Pro ~ % aws ec2 describe-regions --output text          
REGIONS	ec2.eu-north-1.amazonaws.com	opt-in-not-required	eu-north-1
REGIONS	ec2.ap-south-1.amazonaws.com	opt-in-not-required	ap-south-1
REGIONS	ec2.eu-west-3.amazonaws.com	opt-in-not-required	eu-west-3
REGIONS	ec2.eu-west-2.amazonaws.com	opt-in-not-required	eu-west-2
REGIONS	ec2.eu-west-1.amazonaws.com	opt-in-not-required	eu-west-1
REGIONS	ec2.ap-northeast-2.amazonaws.com	opt-in-not-required	ap-northeast-2
REGIONS	ec2.ap-northeast-1.amazonaws.com	opt-in-not-required	ap-northeast-1
REGIONS	ec2.sa-east-1.amazonaws.com	opt-in-not-required	sa-east-1
REGIONS	ec2.ca-central-1.amazonaws.com	opt-in-not-required	ca-central-1
REGIONS	ec2.ap-southeast-1.amazonaws.com	opt-in-not-required	ap-southeast-1
REGIONS	ec2.ap-southeast-2.amazonaws.com	opt-in-not-required	ap-southeast-2
REGIONS	ec2.eu-central-1.amazonaws.com	opt-in-not-required	eu-central-1
REGIONS	ec2.us-east-1.amazonaws.com	opt-in-not-required	us-east-1
REGIONS	ec2.us-east-2.amazonaws.com	opt-in-not-required	us-east-2
REGIONS	ec2.us-west-1.amazonaws.com	opt-in-not-required	us-west-1
REGIONS	ec2.us-west-2.amazonaws.com	opt-in-not-required	us-west-2`

so the script should be `print $4` instead of `print $3`.