### PR TITLE
Fix AOSP_BUILD interpretting "9.0" as regex not fixed string

### DIFF
--- a/templates/build_template.go
+++ b/templates/build_template.go
@@ -168,7 +168,7 @@ get_latest_versions() {
 
   # attempt to automatically pick latest build version and branch. note this is likely to break with any page redesign. should also add some validation here.
   if [ -z "$AOSP_BUILD" ]; then
-    AOSP_BUILD=$(curl --fail -s ${AOSP_URL_BUILD} | grep -A1 "${DEVICE}" | egrep '[a-zA-Z]+ [0-9]{4}\)' | grep "${ANDROID_VERSION}" | tail -1 | cut -d"(" -f2 | cut -d"," -f1)
+    AOSP_BUILD=$(curl --fail -s ${AOSP_URL_BUILD} | grep -A1 "${DEVICE}" | egrep '[a-zA-Z]+ [0-9]{4}\)' | grep -F "${ANDROID_VERSION}" | tail -1 | cut -d"(" -f2 | cut -d"," -f1)
     if [ -z "$AOSP_BUILD" ]; then
       aws_notify_simple "ERROR: Unable to get latest AOSP build information. Stopping build. This lookup is pretty fragile and can break on any page redesign of ${AOSP_URL_BUILD}"
       exit 1
@@ -809,7 +809,7 @@ patch_device_config() {
 
   sed -i 's@PRODUCT_MODEL := AOSP on crosshatch@PRODUCT_MODEL := Pixel 3 XL@' ${BUILD_DIR}/device/google/crosshatch/aosp_crosshatch.mk || true
   sed -i 's@PRODUCT_MODEL := AOSP on blueline@PRODUCT_MODEL := Pixel 3@' ${BUILD_DIR}/device/google/crosshatch/aosp_blueline.mk || true
-  
+
   sed -i 's@PRODUCT_MODEL := AOSP on bonito@PRODUCT_MODEL := Pixel 3a XL@' ${BUILD_DIR}/device/google/bonito/aosp_bonito.mk || true
   sed -i 's@PRODUCT_MODEL := AOSP on sargo@PRODUCT_MODEL := Pixel 3a@' ${BUILD_DIR}/device/google/bonito/aosp_sargo.mk || true
 }


### PR DESCRIPTION
The following line in build_template.go is interpretting "9.0" as regex not a fixed string. I've included all the necessary commands to prove and reproduce and a pull request to fix.

AOSP_BUILD=$(curl --fail -s ${AOSP_URL_BUILD} | grep -A1 "${DEVICE}" | egrep '[a-zA-Z]+ [0-9 {4}\)' | grep "${ANDROID_VERSION}" | tail -1 | cut -d"(" -f2 | cut -d"," -f1)

```
# AOSP_URL_BUILD="https://developers.google.com/android/images"
# AOSP_URL_BRANCH="https://source.android.com/setup/start/build-numbers"
# ANDROID_VERSION="9.0"
# DEVICE=taimen
# curl --fail -s ${AOSP_URL_BUILD} | grep -A1 "${DEVICE}" | egrep '[a-zA-Z]+ [0-9]{4}\)' | grep -F "${ANDROID_VERSION}" | tail -1 | cut -d"(" -f2 | cut -d"," -f1
PQ3A.190801.002
# AOSP_BUILD=$(curl --fail -s ${AOSP_URL_BUILD} | grep -A1 "${DEVICE}" | egrep '[a-zA-Z]+ [0-9]{4}\)' | grep -F "${ANDROID_VERSION}" | tail -1 | cut -d"(" -f2 | cut -d"," -f1)
# curl --fail -s ${AOSP_URL_BRANCH} | grep -A1 "${AOSP_BUILD}" | tail -1 | cut -f2 -d">"|cut -f1 -d"<"
android-9.0.0_r46
# AOSP_BUILD=$(curl --fail -s ${AOSP_URL_BUILD} | grep -A1 "${DEVICE}" | egrep '[a-zA-Z]+ [0-9]{4}\)' | grep "${ANDROID_VERSION}" | tail -1 | cut -d"(" -f2 | cut -d"," -f1)
# curl --fail -s ${AOSP_URL_BRANCH} | grep -A1 "${AOSP_BUILD}" | tail -1 | cut -f2 -d">"|cut -f1 -d"<"

# curl --fail -s ${AOSP_URL_BUILD} | grep -A1 "${DEVICE}" | egrep '[a-zA-Z]+ [0-9]{4}\)' | grep "${ANDROID_VERSION}"
    <td>8.1.0 (OPM1.171019.011, Dec 2017)</td>
    <td>8.1.0 (OPM1.171019.013, Jan 2018)</td>
    <td>8.1.0 (OPM1.171019.018, Feb 2018)</td>
    <td>8.1.0 (OPM1.171019.021, Mar 2018)</td>
    <td>8.1.0 (OPM2.171019.029, Apr 2018)</td>
    <td>8.1.0 (OPM2.171019.029.B1, May 2018)</td>
    <td>9.0.0 (PPR1.180610.009, Aug 2018)</td>
    <td>9.0.0 (PPR2.180905.005, Sep 2018)</td>
    <td>9.0.0 (PPR2.181005.003, Oct 2018)</td>
    <td>9.0.0 (PQ1A.181105.017.A1, Nov 2018)</td>
    <td>9.0.0 (PQ1A.181205.002, Dec 2018)</td>
    <td>9.0.0 (PQ1A.190105.004, Jan 2019)</td>
    <td>9.0.0 (PQ2A.190205.002, Feb 2019)</td>
    <td>9.0.0 (PQ2A.190305.002, Mar 2019)</td>
    <td>9.0.0 (PQ2A.190405.003, Apr 2019)</td>
    <td>9.0.0 (PQ3A.190505.001, May 2019)</td>
    <td>9.0.0 (PQ3A.190605.003, Jun 2019)</td>
    <td>9.0.0 (PQ3A.190705.001, Jul 2019)</td>
    <td>9.0.0 (PQ3A.190801.002, Aug 2019)</td>
    <td>10.0.0 (QP1A.191005.007.A1, Oct 2019)</td>

```