### PR TITLE
Prevent incorrect revision numbers

### DIFF
--- a/templates/build_template.go
+++ b/templates/build_template.go
@@ -222,9 +222,14 @@ check_for_new_versions() {
     echo "Chromium build ($existing_chromium) is up to date"
   else
     echo "Chromium needs to be updated to ${LATEST_CHROMIUM}"
-    needs_update=true
-    BUILD_REASON="$BUILD_REASON 'Chromium version $existing_chromium != $LATEST_CHROMIUM'"
     echo "no" | aws s3 cp - "s3://${AWS_RELEASE_BUCKET}/chromium/included"
+    needs_update=true
+    if [ "$existing_chromium" == "$LATEST_CHROMIUM" ]; then
+      BUILD_REASON="$BUILD_REASON 'Chromium version $existing_chromium built but not installed'"
+    else
+      BUILD_REASON="$BUILD_REASON 'Chromium version $existing_chromium != $LATEST_CHROMIUM'"
+    fi
+    
   fi
 
   # check fdroid

--- a/templates/build_template.go
+++ b/templates/build_template.go
@@ -229,7 +229,6 @@ check_for_new_versions() {
     else
       BUILD_REASON="$BUILD_REASON 'Chromium version $existing_chromium != $LATEST_CHROMIUM'"
     fi
-    
   fi
 
   # check fdroid


### PR DESCRIPTION
This is to prevent the AOSP build number in sargo-vendor from updating if a build crashes. I had something happen where the build didn't finish, but sargo-vendor had already updated so the following builds thought AOSP was up-to-date

Similarly, I added some steps when checking if Chromium is updated to see if has been actually included in the most recent build. Currently, if a build dies after Chromium has been built, the revision number is updated even though the build never finished, so the script won't detect any need for changes on the next build. To prevent building Chromium repeatedly, I added a parameter to check if the most recent version built was included in the last release.

Look these over and let me know what you think, or if you have anything else in mind. I tested these changes but also please check if I made a mistake somewhere.