### PR TITLE
Fix missing notifications in Messaging app

### DIFF
--- a/templates/build_template.go
+++ b/templates/build_template.go
@@ -728,6 +728,7 @@ apply_patches() {
   patch_priv_ext
   patch_launcher
   patch_broken_alarmclock
+  patch_broken_messaging
   patch_disable_apex
 }
 
@@ -750,6 +751,16 @@ patch_broken_alarmclock() {
   if ! grep -q "android.permission.FOREGROUND_SERVICE" ${BUILD_DIR}/packages/apps/DeskClock/AndroidManifest.xml; then
     sed -i '/<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" \/>/a <uses-permission android:name="android.permission.FOREGROUND_SERVICE" \/>' ${BUILD_DIR}/packages/apps/DeskClock/AndroidManifest.xml
     sed -i 's@<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="28" />@<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="25" />@' ${BUILD_DIR}/packages/apps/DeskClock/AndroidManifest.xml
+  fi
+}
+
+# TODO: remove once this once fix from upstream makes it into release branch
+# https://android.googlesource.com/platform/packages/apps/Messaging/+/8e71d1b707123e1b48b5529b1661d53762922400%5E%21/
+patch_broken_messaging() {
+  log_header ${FUNCNAME}
+
+  if ! grep -q "android:targetSdkVersion=\"24\"" ${BUILD_DIR}/packages/apps/Messaging/AndroidManifest.xml; then
+    sed -i 's@<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="28" />@<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="24" />@' ${BUILD_DIR}/packages/apps/Messaging/AndroidManifest.xml
   fi
 }
 


### PR DESCRIPTION
I noticed I wasn't getting any notifications from the default Messaging app, seems that the SDK version is set too high without Google adding the logic code for it.

I'm surprised no one else has noticed this, so feel free to ignore this PR if it you can't replicate it. I'm building AOSP locally based on your script (thanks for making it!).  So it's possible I'm getting a different version of the Messaging app somehow.

Tested on my sargo. QQ1A.191205.011 , android-10.0.0_r16 



The quick hacky fix that was implemented:
https://android.googlesource.com/platform/packages/apps/Messaging/+/8e71d1b707123e1b48b5529b1661d53762922400%5E!/

The logic they should have merged:
https://developer.android.com/training/notify-user/channels