### PR TITLE
Add support for Pixel 5

### DIFF
--- a/cli/deploy.go
+++ b/cli/deploy.go
@@ -34,11 +34,11 @@ var supportedRegions = []string{"ap-northeast-1", "ap-northeast-2", "ap-northeas
 var supportedDevicesFriendly = []string{
 	"Pixel 2", "Pixel 2 XL",
 	"Pixel 3", "Pixel 3 XL", "Pixel 3a", "Pixel 3a XL",
-	"Pixel 4", "Pixel 4 XL", "Pixel 4a"}
+	"Pixel 4", "Pixel 4 XL", "Pixel 4a", "Pixel 5"}
 var supportedDevicesCodename = []string{
 	"walleye", "taimen",
 	"blueline", "crosshatch", "sargo", "bonito",
-	"flame", "coral", "sunfish"}
+	"flame", "coral", "sunfish", "redfin"}
 var supportDevicesOutput string
 
 func init() {

--- a/templates/build_template.go
+++ b/templates/build_template.go
@@ -42,6 +42,11 @@ case "${DEVICE}" in
     DEVICE_COMMON=sunfish
     AVB_MODE=vbmeta_chained_v2
     ;;
+  redfin)
+    DEVICE_FAMILY=redfin
+    DEVICE_COMMON=redfin
+    AVB_MODE=vbmeta_chained_v2
+    ;;
   *)
     echo "error: unknown device ${DEVICE}"
     exit 1
@@ -643,7 +648,9 @@ setup_vendor() {
   log_header "${FUNCNAME[0]}"
 
   # new dependency to extract ota partitions
-  sudo DEBIAN_FRONTEND=noninteractive apt-get -y install python-protobuf
+  # one of the scripts depends on python2, the other on python3
+  sudo DEBIAN_FRONTEND=noninteractive apt-get -y install python-protobuf python3-protobuf python3-pip
+  pip3 install --user protobuf -U
 
   # get vendor files (with timeout)
   timeout 30m "${BUILD_DIR}/vendor/android-prepare-vendor/execute-all.sh" --debugfs --yes --device "${DEVICE}" \
@@ -698,14 +705,24 @@ patch_11_issues() {
     # ID0:Face:Strong
     biometric_sensors="0:8:15"
   fi
-  sed -i '$ s/^<\/resources>//' "${BUILD_DIR}/device/google/${DEVICE_COMMON}/overlay/frameworks/base/core/res/res/values/config.xml"
-  cat <<EOF >> "${BUILD_DIR}/device/google/${DEVICE_COMMON}/overlay/frameworks/base/core/res/res/values/config.xml"
+  if [ "${DEVICE_COMMON}" == "redfin" ]
+  then
+    sed -i '$ s/^<\/resources>//' "${BUILD_DIR}/device/google/${DEVICE_COMMON}/${DEVICE_COMMON}/overlay/frameworks/base/core/res/res/values/config.xml"
+    cat <<EOF >> "${BUILD_DIR}/device/google/${DEVICE_COMMON}/${DEVICE_COMMON}/overlay/frameworks/base/core/res/res/values/config.xml"
     <string-array name="config_biometric_sensors" translatable="false" >
         <item>${biometric_sensors}</item>
     </string-array>
 </resources>
 EOF
-
+  else
+    sed -i '$ s/^<\/resources>//' "${BUILD_DIR}/device/google/${DEVICE_COMMON}/overlay/frameworks/base/core/res/res/values/config.xml"
+    cat <<EOF >> "${BUILD_DIR}/device/google/${DEVICE_COMMON}/overlay/frameworks/base/core/res/res/values/config.xml"
+    <string-array name="config_biometric_sensors" translatable="false" >
+        <item>${biometric_sensors}</item>
+    </string-array>
+</resources>
+EOF
+  fi
 }
 
 patch_launcher() {
@@ -804,6 +821,8 @@ patch_device_config() {
   sed -i 's@PRODUCT_MODEL := AOSP on flame@PRODUCT_MODEL := Pixel 4@' "${BUILD_DIR}/device/google/coral/aosp_flame.mk" || true
 
   sed -i 's@PRODUCT_MODEL := AOSP on sunfish@PRODUCT_MODEL := Pixel 4A@' "${BUILD_DIR}/device/google/sunfish/aosp_sunfish.mk" || true
+
+  sed -i 's@PRODUCT_MODEL := AOSP on redfin@PRODUCT_MODEL := Pixel 5@' "${BUILD_DIR}/device/google/redfin/aosp_redfin.mk" || true
 }
 
 patch_add_apps() {


### PR DESCRIPTION
These changes should work for redfin. Tested against latest.json generated using your [latest.json script](https://github.com/AOSPAlliance/vendor_google_devices/blob/android11/update_config.py) and with [android-prepare-vendor/android11](https://github.com/AOSPAlliance/android-prepare-vendor/tree/android11/). 

Would need your fork of android-prepare-vendor updated as well. Since the extraction scripts use both [python2](https://github.com/AOSPAlliance/android-prepare-vendor/blob/android11/scripts/extract_android_ota_payload/extract_android_ota_payload.py#L1) and [python3](https://github.com/AOSPAlliance/android-prepare-vendor/blob/android11/scripts/carriersettings-extractor/carriersettings_extractor.py#L1), I had to install protobuf for both to get it to build. Let me know if you spot any issues.