### PR TITLE
Fix for Windows deployment

### DIFF
--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -158,7 +158,9 @@ func (t *Templates) renderBuildScript() ([]byte, error) {
 	// insert the generated vars and funcs into raw build script
 	updatedBuildScript := strings.Replace(t.templateFiles.BuildScript, defaultGeneratedVarReplaceString, string(renderedBuildScriptTemplate), 1)
 
-	return []byte(updatedBuildScript), nil
+	fixedBuildScript := strings.Replace(updatedBuildScript, "\r\n", "\n", -1)
+
+	return []byte(fixedBuildScript), nil
 }
 
 func (t *Templates) renderLambdaFunction() ([]byte, error) {


### PR DESCRIPTION
A small change that removes the carriage returns from the build script. There are still carriage returns in `main.tf` and `lambda_spot_function.py` but it seems like those are handled fine.

I'm running a test build right now but everything looks good so far. Hopefully fixes #185.